### PR TITLE
Add SmartOS SMF manifest

### DIFF
--- a/manifest/smartos_exporter.xml
+++ b/manifest/smartos_exporter.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+    <service_bundle type="manifest" name="smartos_exporter">
+    <service name="network/smartos_exporter" type="service" version="1">
+        <create_default_instance enabled="true"/>
+        <single_instance/>
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+
+        <method_context>
+        </method_context>
+
+        <exec_method type="method" name="start" exec="/opt/local/sbin/smartos_exporter" timeout_seconds="60"/>
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="child"/>
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+
+        <property_group name="application" type="application">
+        </property_group>
+
+        <stability value="Evolving"/>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    Golang program for gathering SmartOS statistics and providing them to Prometheus.
+                </loctext>
+            </common_name>
+        </template>
+    </service>
+</service_bundle>


### PR DESCRIPTION
Basic manifest which can be useful for launching smartos_exporter as a service.