### PR TITLE
Introduce a sleep on speedy commands

### DIFF
--- a/collector/df.go
+++ b/collector/df.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 	// Prometheus Go toolset
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -64,6 +65,9 @@ func (e *ZoneDfCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (e *ZoneDfCollector) dfList() {
+	// on Brand LX zone the call to waitid causes a SIG_ABRT when certain
+	// conditions are met. On speedy command, introducing a sleep seems to help.
+	time.Sleep(100 * time.Millisecond)
 	out, eerr := exec.Command("df").Output()
 	if eerr != nil {
 		log.Errorf("error on executing df: %v", eerr)

--- a/collector/uptime.go
+++ b/collector/uptime.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"time"
 	// Prometheus Go toolset
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -58,6 +59,9 @@ func (e *LoadAverageCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (e *LoadAverageCollector) uptime() {
+	// on Brand LX zone the call to waitid causes a SIG_ABRT when certain
+	// conditions are met. On speedy command, introducing a sleep seems to help.
+	time.Sleep(100 * time.Millisecond)
 	out, eerr := exec.Command("uptime").Output()
 	if eerr != nil {
 		log.Errorf("error on executing uptime: %v", eerr)


### PR DESCRIPTION
In order to avoid a race condition on Brand LX zones when using
wait_id() syscall, we introduce a sleep on speedy commands to avoid a
SIG_ABRT.